### PR TITLE
RU-T50 Call notes and Inbox fix

### DIFF
--- a/src/components/calls/__tests__/call-notes-modal-new.test.tsx
+++ b/src/components/calls/__tests__/call-notes-modal-new.test.tsx
@@ -66,9 +66,9 @@ jest.mock('react-native-keyboard-controller', () => ({
     const { View } = require('react-native');
     return <View testID="keyboard-aware-scroll-view">{children}</View>;
   },
-  KeyboardStickyView: ({ children }: any) => {
+  KeyboardAvoidingView: ({ children }: any) => {
     const { View } = require('react-native');
-    return <View testID="keyboard-sticky-view">{children}</View>;
+    return <View testID="keyboard-avoiding-view">{children}</View>;
   },
 }));
 

--- a/src/components/calls/call-notes-modal.tsx
+++ b/src/components/calls/call-notes-modal.tsx
@@ -3,7 +3,7 @@ import { useColorScheme } from 'nativewind';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FlatList, Keyboard, Modal, SafeAreaView, StyleSheet, TouchableOpacity, View } from 'react-native';
-import { KeyboardStickyView } from 'react-native-keyboard-controller';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 
 import { useAnalytics } from '@/hooks/use-analytics';
 import { useAuthStore } from '@/lib/auth';
@@ -106,44 +106,44 @@ const CallNotesModal = ({ isOpen, onClose, callId }: CallNotesModalProps) => {
   return (
     <Modal visible={isOpen} animationType="slide" presentationStyle="pageSheet" onRequestClose={handleClose}>
       <SafeAreaView style={[styles.container, isDark && styles.containerDark]}>
-        {/* Header */}
-        <View style={[styles.header, isDark && styles.headerDark]}>
-          <Heading size="lg">{t('callNotes.title')}</Heading>
-          <TouchableOpacity onPress={handleClose} style={styles.closeButton} testID="close-button">
-            <X size={24} color={isDark ? '#D1D5DB' : '#374151'} />
-          </TouchableOpacity>
-        </View>
+        <KeyboardAvoidingView style={styles.keyboardAvoiding} behavior="padding" keyboardVerticalOffset={0}>
+          {/* Header */}
+          <View style={[styles.header, isDark && styles.headerDark]}>
+            <Heading size="lg">{t('callNotes.title')}</Heading>
+            <TouchableOpacity onPress={handleClose} style={styles.closeButton} testID="close-button">
+              <X size={24} color={isDark ? '#D1D5DB' : '#374151'} />
+            </TouchableOpacity>
+          </View>
 
-        {/* Search Bar */}
-        <View style={styles.searchContainer}>
-          <Input className="w-full rounded-lg bg-gray-100 dark:bg-gray-700">
-            <InputSlot>
-              <SearchIcon size={20} className="text-gray-500" />
-            </InputSlot>
-            <InputField placeholder={t('callNotes.searchPlaceholder')} value={searchQuery} onChangeText={setSearchQuery} />
-          </Input>
-        </View>
+          {/* Search Bar */}
+          <View style={styles.searchContainer}>
+            <Input className="w-full rounded-lg bg-gray-100 dark:bg-gray-700">
+              <InputSlot>
+                <SearchIcon size={20} className="text-gray-500" />
+              </InputSlot>
+              <InputField placeholder={t('callNotes.searchPlaceholder')} value={searchQuery} onChangeText={setSearchQuery} />
+            </Input>
+          </View>
 
-        {/* Notes List */}
-        <View style={styles.listContainer}>
-          {isNotesLoading ? (
-            <Loading />
-          ) : filteredNotes.length > 0 ? (
-            <FlatList
-              data={filteredNotes}
-              renderItem={renderNote}
-              keyExtractor={(item) => item.CallNoteId}
-              contentContainerStyle={styles.listContent}
-              showsVerticalScrollIndicator={true}
-              keyboardShouldPersistTaps="handled"
-            />
-          ) : (
-            <ZeroState heading={t('callNotes.noNotesFound')} />
-          )}
-        </View>
+          {/* Notes List */}
+          <View style={styles.listContainer}>
+            {isNotesLoading ? (
+              <Loading />
+            ) : filteredNotes.length > 0 ? (
+              <FlatList
+                data={filteredNotes}
+                renderItem={renderNote}
+                keyExtractor={(item) => item.CallNoteId}
+                contentContainerStyle={styles.listContent}
+                showsVerticalScrollIndicator={true}
+                keyboardShouldPersistTaps="handled"
+              />
+            ) : (
+              <ZeroState heading={t('callNotes.noNotesFound')} />
+            )}
+          </View>
 
-        {/* Add Note Section - Sticks to keyboard */}
-        <KeyboardStickyView offset={{ opened: 0, closed: 0 }}>
+          {/* Add Note Section */}
           <View style={[styles.footer, isDark && styles.footerDark]}>
             <VStack space="sm" className="w-full">
               <Text className="font-medium">{t('callNotes.addNoteLabel')}</Text>
@@ -161,7 +161,7 @@ const CallNotesModal = ({ isOpen, onClose, callId }: CallNotesModalProps) => {
               </Button>
             </HStack>
           </View>
-        </KeyboardStickyView>
+        </KeyboardAvoidingView>
       </SafeAreaView>
     </Modal>
   );
@@ -174,6 +174,9 @@ const styles = StyleSheet.create({
   },
   containerDark: {
     backgroundColor: '#1F2937',
+  },
+  keyboardAvoiding: {
+    flex: 1,
   },
   header: {
     flexDirection: 'row',

--- a/src/components/calls/call-notes-modal.tsx
+++ b/src/components/calls/call-notes-modal.tsx
@@ -26,6 +26,8 @@ interface CallNotesModalProps {
   callId: string;
 }
 
+const keyExtractor = (item: { CallNoteId: string }) => item.CallNoteId;
+
 const CallNotesModal = ({ isOpen, onClose, callId }: CallNotesModalProps) => {
   const { t } = useTranslation();
   const { trackEvent } = useAnalytics();
@@ -130,14 +132,7 @@ const CallNotesModal = ({ isOpen, onClose, callId }: CallNotesModalProps) => {
             {isNotesLoading ? (
               <Loading />
             ) : filteredNotes.length > 0 ? (
-              <FlatList
-                data={filteredNotes}
-                renderItem={renderNote}
-                keyExtractor={(item) => item.CallNoteId}
-                contentContainerStyle={styles.listContent}
-                showsVerticalScrollIndicator={true}
-                keyboardShouldPersistTaps="handled"
-              />
+              <FlatList data={filteredNotes} renderItem={renderNote} keyExtractor={keyExtractor} contentContainerStyle={styles.listContent} showsVerticalScrollIndicator={true} keyboardShouldPersistTaps="handled" />
             ) : (
               <ZeroState heading={t('callNotes.noNotesFound')} />
             )}

--- a/src/components/notifications/NotificationDetail.tsx
+++ b/src/components/notifications/NotificationDetail.tsx
@@ -1,7 +1,6 @@
-import { useNotifications } from '@novu/react-native';
 import { ArrowLeft, Calendar, ExternalLink, Trash2 } from 'lucide-react-native';
 import { colorScheme } from 'nativewind';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Animated, Dimensions, Platform, Pressable, SafeAreaView, StatusBar, StyleSheet, Text, View } from 'react-native';
 
 // Define the interface directly in this file
@@ -29,30 +28,8 @@ const SIDEBAR_WIDTH = Math.min(width * 0.85, 400);
 const STATUS_BAR_HEIGHT = Platform.OS === 'ios' ? 44 : StatusBar.currentHeight || 0;
 
 export const NotificationDetail = ({ notification, onClose, onDelete, onNavigateToReference }: NotificationDetailProps) => {
-  const { refetch } = useNotifications();
-  const slideAnim = React.useRef(new Animated.Value(SIDEBAR_WIDTH)).current;
-  const fadeAnim = React.useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    // Mark as read when opened - we'll just refetch to sync with server
-    if (!notification.read && notification.id) {
-      refetch();
-    }
-
-    // Animate in
-    Animated.parallel([
-      Animated.timing(slideAnim, {
-        toValue: 0,
-        duration: 300,
-        useNativeDriver: true,
-      }),
-      Animated.timing(fadeAnim, {
-        toValue: 1,
-        duration: 300,
-        useNativeDriver: true,
-      }),
-    ]).start();
-  }, [notification, refetch, slideAnim, fadeAnim]);
+  const slideAnim = React.useRef(new Animated.Value(0)).current;
+  const fadeAnim = React.useRef(new Animated.Value(1)).current;
 
   const handleClose = () => {
     // Animate out

--- a/src/components/notifications/NotificationInbox.tsx
+++ b/src/components/notifications/NotificationInbox.tsx
@@ -1,4 +1,5 @@
 import { useNotifications } from '@novu/react-native';
+import { router } from 'expo-router';
 import { CheckCircle, ChevronRight, Circle, ExternalLink, MoreVertical, Trash2, X } from 'lucide-react-native';
 import { colorScheme } from 'nativewind';
 import React, { useEffect, useRef, useState } from 'react';
@@ -10,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { FlatList } from '@/components/ui/flat-list';
 import { Modal, ModalBackdrop, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@/components/ui/modal';
 import { Text } from '@/components/ui/text';
+import { logger } from '@/lib/logging';
 import { useCoreStore } from '@/stores/app/core-store';
 import { useToastStore } from '@/stores/toast/store';
 import { type NotificationPayload } from '@/types/notification';
@@ -157,21 +159,24 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
       if (isSelectionMode) {
         toggleNotificationSelection(notification.id);
       } else {
+        // Mark unread notifications as read via the Novu SDK; the SDK
+        // optimistically updates its cache, refreshing inbox state.
+        notification.markAsRead?.();
         setSelectedNotification(notification);
       }
     },
     [isSelectionMode, toggleNotificationSelection]
   );
 
-  const handleNotificationLongPress = React.useCallback((notification: NotificationPayload) => {
-    setIsSelectionMode((prevMode) => {
-      if (!prevMode) {
+  const handleNotificationLongPress = React.useCallback(
+    (notification: NotificationPayload) => {
+      if (!isSelectionMode) {
         setSelectedNotificationIds(new Set([notification.id]));
-        return true;
+        setIsSelectionMode(true);
       }
-      return prevMode;
-    });
-  }, []);
+    },
+    [isSelectionMode]
+  );
 
   const enterSelectionMode = () => {
     setIsSelectionMode(true);
@@ -231,9 +236,12 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
 
   const handleNavigateToReference = React.useCallback(
     (referenceType: string, referenceId: string) => {
-      // TODO: Implement navigation based on reference type
-      console.log('Navigate to:', referenceType, referenceId);
-      onClose();
+      if (referenceType === 'call') {
+        router.push(`/call/${referenceId}`);
+        onClose();
+      } else {
+        logger.info({ message: 'Notification reference navigation not supported for type', context: { referenceType, referenceId } });
+      }
     },
     [onClose]
   );
@@ -245,17 +253,18 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
         title: item.subject,
         body: item.body,
         createdAt: item.createdAt,
-        read: item.read,
+        read: item.isRead,
         type: item.type,
         referenceId: item.payload?.referenceId,
         referenceType: item.payload?.referenceType,
         metadata: item.payload?.metadata,
+        markAsRead: !item.isRead && typeof item.read === 'function' ? () => item.read() : undefined,
       };
 
       return (
         <NotificationRow
           notification={notification}
-          unread={!item.read}
+          unread={!item.isRead}
           isSelectionMode={isSelectionMode}
           isSelected={selectedNotificationIds.has(notification.id)}
           onPress={handleNotificationPress}

--- a/src/components/notifications/NotificationInbox.tsx
+++ b/src/components/notifications/NotificationInbox.tsx
@@ -24,6 +24,69 @@ interface NotificationInboxProps {
   onClose: () => void;
 }
 
+interface NotificationRowProps {
+  notification: NotificationPayload;
+  unread: boolean;
+  isSelectionMode: boolean;
+  isSelected: boolean;
+  onPress: (notification: NotificationPayload) => void;
+  onLongPress: (notification: NotificationPayload) => void;
+  onNavigateToReference: (referenceType: string, referenceId: string) => void;
+}
+
+const NotificationRow = React.memo(
+  ({ notification, unread, isSelectionMode, isSelected, onPress, onLongPress, onNavigateToReference }: NotificationRowProps) => {
+    const handlePress = React.useCallback(() => onPress(notification), [onPress, notification]);
+    const handleLongPress = React.useCallback(() => onLongPress(notification), [onLongPress, notification]);
+    const handleNavigate = React.useCallback(
+      () => notification.referenceType && notification.referenceId && onNavigateToReference(notification.referenceType, notification.referenceId),
+      [onNavigateToReference, notification.referenceType, notification.referenceId]
+    );
+
+    return (
+      <Pressable onPress={handlePress} onLongPress={handleLongPress} style={[styles.notificationItem, unread ? styles.unreadNotificationItem : {}, isSelected ? styles.selectedNotificationItem : {}]}>
+        {unread ? <View style={styles.unreadIndicator} /> : null}
+
+        {isSelectionMode ? (
+          <View style={styles.selectionIndicator}>
+            {isSelected ? <CheckCircle size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} /> : <Circle size={24} className="text-gray-400 dark:text-gray-500" strokeWidth={2} />}
+          </View>
+        ) : null}
+
+        <View style={styles.notificationContent}>
+          <Text style={[styles.notificationBody, unread ? styles.unreadNotificationText : {}]}>{notification.title}</Text>
+          <Text style={styles.timestamp}>
+            {new Date(notification.createdAt).toLocaleDateString()} {new Date(notification.createdAt).toLocaleTimeString()}
+          </Text>
+        </View>
+
+        {!isSelectionMode ? (
+          notification.referenceType && notification.referenceId ? (
+            <View style={styles.actionButtons}>
+              <Button onPress={handleNavigate} variant="outline" className="size-8 p-0">
+                <ExternalLink size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} />
+              </Button>
+              <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
+            </View>
+          ) : (
+            <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
+          )
+        ) : null}
+      </Pressable>
+    );
+  },
+  (prev, next) =>
+    prev.notification.id === next.notification.id &&
+    prev.notification.title === next.notification.title &&
+    prev.notification.createdAt === next.notification.createdAt &&
+    prev.notification.referenceType === next.notification.referenceType &&
+    prev.notification.referenceId === next.notification.referenceId &&
+    prev.unread === next.unread &&
+    prev.isSelectionMode === next.isSelectionMode &&
+    prev.isSelected === next.isSelected
+);
+NotificationRow.displayName = 'NotificationRow';
+
 export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) => {
   const activeUnitId = useCoreStore((state) => state.activeUnitId);
   const config = useCoreStore((state: any) => state.config);
@@ -77,15 +140,7 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
     }
   }, [isOpen, slideAnim, fadeAnim]);
 
-  const handleNotificationPress = (notification: NotificationPayload) => {
-    if (isSelectionMode) {
-      toggleNotificationSelection(notification.id);
-    } else {
-      setSelectedNotification(notification);
-    }
-  };
-
-  const toggleNotificationSelection = (notificationId: string) => {
+  const toggleNotificationSelection = React.useCallback((notificationId: string) => {
     setSelectedNotificationIds((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(notificationId)) {
@@ -95,7 +150,28 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
       }
       return newSet;
     });
-  };
+  }, []);
+
+  const handleNotificationPress = React.useCallback(
+    (notification: NotificationPayload) => {
+      if (isSelectionMode) {
+        toggleNotificationSelection(notification.id);
+      } else {
+        setSelectedNotification(notification);
+      }
+    },
+    [isSelectionMode, toggleNotificationSelection]
+  );
+
+  const handleNotificationLongPress = React.useCallback((notification: NotificationPayload) => {
+    setIsSelectionMode((prevMode) => {
+      if (!prevMode) {
+        setSelectedNotificationIds(new Set([notification.id]));
+        return true;
+      }
+      return prevMode;
+    });
+  }, []);
 
   const enterSelectionMode = () => {
     setIsSelectionMode(true);
@@ -153,68 +229,43 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
     [showToast, refetch]
   );
 
-  const handleNavigateToReference = (referenceType: string, referenceId: string) => {
-    // TODO: Implement navigation based on reference type
-    console.log('Navigate to:', referenceType, referenceId);
-    onClose();
-  };
+  const handleNavigateToReference = React.useCallback(
+    (referenceType: string, referenceId: string) => {
+      // TODO: Implement navigation based on reference type
+      console.log('Navigate to:', referenceType, referenceId);
+      onClose();
+    },
+    [onClose]
+  );
 
-  const renderItem = ({ item }: { item: any }) => {
-    const notification: NotificationPayload = {
-      id: item.id,
-      title: item.subject,
-      body: item.body,
-      createdAt: item.createdAt,
-      read: item.read,
-      type: item.type,
-      referenceId: item.payload?.referenceId,
-      referenceType: item.payload?.referenceType,
-      metadata: item.payload?.metadata,
-    };
+  const renderItem = React.useCallback(
+    ({ item }: { item: any }) => {
+      const notification: NotificationPayload = {
+        id: item.id,
+        title: item.subject,
+        body: item.body,
+        createdAt: item.createdAt,
+        read: item.read,
+        type: item.type,
+        referenceId: item.payload?.referenceId,
+        referenceType: item.payload?.referenceType,
+        metadata: item.payload?.metadata,
+      };
 
-    const isSelected = selectedNotificationIds.has(notification.id);
-
-    return (
-      <Pressable
-        onPress={() => handleNotificationPress(notification)}
-        onLongPress={() => {
-          if (!isSelectionMode) {
-            enterSelectionMode();
-            toggleNotificationSelection(notification.id);
-          }
-        }}
-        style={[styles.notificationItem, !item.read ? styles.unreadNotificationItem : {}, isSelected ? styles.selectedNotificationItem : {}]}
-      >
-        {!item.read ? <View style={styles.unreadIndicator} /> : null}
-
-        {isSelectionMode ? (
-          <View style={styles.selectionIndicator}>
-            {isSelected ? <CheckCircle size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} /> : <Circle size={24} className="text-gray-400 dark:text-gray-500" strokeWidth={2} />}
-          </View>
-        ) : null}
-
-        <View style={styles.notificationContent}>
-          <Text style={[styles.notificationBody, !item.read ? styles.unreadNotificationText : {}]}>{notification.title}</Text>
-          <Text style={styles.timestamp}>
-            {new Date(notification.createdAt).toLocaleDateString()} {new Date(notification.createdAt).toLocaleTimeString()}
-          </Text>
-        </View>
-
-        {!isSelectionMode ? (
-          notification.referenceType && notification.referenceId ? (
-            <View style={styles.actionButtons}>
-              <Button onPress={() => handleNavigateToReference(notification.referenceType!, notification.referenceId!)} variant="outline" className="size-8 p-0">
-                <ExternalLink size={24} className="text-primary-500 dark:text-primary-400" strokeWidth={2} />
-              </Button>
-              <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
-            </View>
-          ) : (
-            <ChevronRight size={24} className="ml-2 text-gray-400" strokeWidth={2} />
-          )
-        ) : null}
-      </Pressable>
-    );
-  };
+      return (
+        <NotificationRow
+          notification={notification}
+          unread={!item.read}
+          isSelectionMode={isSelectionMode}
+          isSelected={selectedNotificationIds.has(notification.id)}
+          onPress={handleNotificationPress}
+          onLongPress={handleNotificationLongPress}
+          onNavigateToReference={handleNavigateToReference}
+        />
+      );
+    },
+    [isSelectionMode, selectedNotificationIds, handleNotificationPress, handleNotificationLongPress, handleNavigateToReference]
+  );
 
   const renderFooter = () => {
     if (!hasMore) return null;

--- a/src/components/notifications/NotificationInbox.tsx
+++ b/src/components/notifications/NotificationInbox.tsx
@@ -258,7 +258,16 @@ export const NotificationInbox = ({ isOpen, onClose }: NotificationInboxProps) =
         referenceId: item.payload?.referenceId,
         referenceType: item.payload?.referenceType,
         metadata: item.payload?.metadata,
-        markAsRead: !item.isRead && typeof item.read === 'function' ? () => item.read() : undefined,
+        markAsRead:
+          !item.isRead && typeof item.read === 'function'
+            ? async () => {
+                try {
+                  await item.read();
+                } catch (error) {
+                  logger.warn({ message: 'Failed to mark notification as read', context: { error } });
+                }
+              }
+            : undefined,
       };
 
       return (

--- a/src/components/notifications/__tests__/NotificationInbox.test.tsx
+++ b/src/components/notifications/__tests__/NotificationInbox.test.tsx
@@ -61,6 +61,7 @@ const MockNotificationInbox = ({ isOpen, onClose }: { isOpen: boolean; onClose: 
       }
       setSelectedNotificationIds(newSet);
     } else {
+      notification.markAsRead?.();
       setSelectedNotification(notification);
     }
   };
@@ -167,6 +168,7 @@ describe('NotificationInbox', () => {
         referenceType: 'call',
         metadata: {},
       },
+      markAsRead: jest.fn(),
     },
     {
       id: '2',
@@ -416,6 +418,32 @@ describe('NotificationInbox', () => {
     // Should show notification detail
     expect(queryByText('Notification Detail')).toBeTruthy();
     expect(queryByText('Notifications')).toBeNull();
+  });
+
+  it('marks an unread notification as read when opening the detail', async () => {
+    const { getByTestId } = render(
+      <NotificationInbox isOpen={true} onClose={mockOnClose} />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('notification-1'));
+    });
+
+    expect((mockNotifications[0] as any).markAsRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke mark-as-read for an already-read notification', async () => {
+    const { getByTestId, queryByText } = render(
+      <NotificationInbox isOpen={true} onClose={mockOnClose} />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('notification-2'));
+    });
+
+    // Already-read notification has no markAsRead attached; detail still opens
+    expect((mockNotifications[0] as any).markAsRead).not.toHaveBeenCalled();
+    expect(queryByText('Notification Detail')).toBeTruthy();
   });
 
   it('resets state when component closes', async () => {

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -8,6 +8,7 @@ export interface NotificationPayload {
   referenceId?: string;
   referenceType?: 'call' | 'message' | 'status' | 'note' | 'other';
   metadata?: Record<string, any>;
+  markAsRead?: () => void;
 }
 
 export interface NotificationDetailProps {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This PR addresses fixes and improvements to the Call Notes modal and Notification Inbox components.

### Call Notes Modal
Replaced `KeyboardStickyView` with `KeyboardAvoidingView` to wrap the entire modal content (header, search bar, notes list, and footer) instead of just the footer. This provides more consistent keyboard handling behavior where the full view adjusts when the keyboard appears, rather than only sticking the input section to the keyboard.

### Notification Inbox
Refactored the notification list for improved rendering performance:
- Extracted individual notification rows into a memoized `NotificationRow` component with a custom comparison function to prevent unnecessary re-renders
- Wrapped event handlers (`handleNotificationPress`, `handleNotificationLongPress`, `toggleNotificationSelection`, `handleNavigateToReference`, and `renderItem`) in `useCallback` to stabilize references and reduce re-renders
- Separated long-press selection logic into its own dedicated handler

### Notification Detail
Removed the entrance animation (slide and fade-in) and the automatic read-marking behavior (via Novu `useNotifications` refetch) that occurred when opening an unread notification. The detail panel now appears immediately without animation.
<!-- kody-pr-summary:end -->